### PR TITLE
Generate carrier files without overwriting state field in stock.picking

### DIFF
--- a/base_delivery_carrier_files/stock.py
+++ b/base_delivery_carrier_files/stock.py
@@ -84,6 +84,11 @@ class stock_move(models.Model):
     def write(self, values):
         write_result = super(stock_move, self).write(values)
         if values.get('state') and values['state'] == 'done':
-            if self.picking_id.state == 'done':
-                self.picking_id.generate_carrier_files()
+            picking_ids = map(lambda p: p.id, self.mapped('picking_id'))
+            done_pickings = self.env['stock.picking'].search([
+                ('id', 'in', picking_ids),
+                ('state', '=', 'done')
+            ])
+            if done_pickings:
+                done_pickings.generate_carrier_files()
         return write_result


### PR DESCRIPTION
I've made a workaround for this PR https://github.com/OCA/carrier-delivery/pull/47
It's possible to generate carrier files without overwriting state field in stock.picking model. I've done that by inheriting write method of stock.move, if state is set to done I check the state of the related picking, if it's done too then is the time to call to the generate carrier file function.

I've tested it and the tests passed with this change. @kkarolis check it out and tell me how it looks this fix to you.

cc:  @yvaucher
